### PR TITLE
Add stone pickaxe to Tetris

### DIFF
--- a/DTW/Tetris/map.json
+++ b/DTW/Tetris/map.json
@@ -54,8 +54,9 @@
 			"items": [
 				{"type": "item", "material": "iron sword", "slot": 0},
 				{"type": "item", "material": "bow", "slot": 1},
-				{"type": "item", "material": "stone axe", "slot":2},
-				{"type": "item", "material": "wood", "slot": 3, "amount": 64},
+				{"type": "item", "material": "stone pickaxe", "slot": 2},
+				{"type": "item", "material": "stone axe", "slot": 3},
+				{"type": "item", "material": "wood", "slot": 4, "amount": 64},
 
 				{"type": "item", "material": "cooked beef", "slot": 8, "amount": 64},
 				{"type": "item", "material": "arrow", "slot": 9, "amount": 64},


### PR DESCRIPTION
For defense, since map gets rushed easy. Should have some extent of defense capabilities, especially with a map out of clay.