### PR TITLE
changed spawn protection

### DIFF
--- a/CTW/Golden_Drought/map.json
+++ b/CTW/Golden_Drought/map.json
@@ -111,7 +111,7 @@
 		{"id": "magenta-room", "min": "-119, 13, 29", "max": "-130, oo, 18"},
 		{"id": "pink-room", "min": "-119, 13, -19", "max": "-130, oo, -30"},
 
-		{"id": "blue-spawn-protection", "type": "cuboid", "min": "122, 13, -4", "max": "87, oo, 3"},
-		{"id": "red-spawn-protection", "type": "cuboid", "min": "-123, 13, 3", "max": "-88, oo, -4"}
+		{"id": "blue-spawn-protection", "type": "cuboid", "min": "133, 0, -11", "max": "64, oo, 11"},
+		{"id": "red-spawn-protection", "type": "cuboid", "min": "-137, 0, 10", "max": "-65, oo, -12"},
 	]
 }


### PR DESCRIPTION
Make Spawn regions (Protection on Golden Drought) Bigger.

		{"id": "blue-spawn-protection", "type": "cuboid", "min": "133, 0, -11", "max": "64, oo, 11"},
		{"id": "red-spawn-protection", "type": "cuboid", "min": "-137, 0, 10", "max": "-65, oo, -12"},