### PR TITLE
Prevent iron block drops on Golden Drought

### DIFF
--- a/CTW/Golden_Drought/map.json
+++ b/CTW/Golden_Drought/map.json
@@ -84,7 +84,7 @@
 
 	"itemremove": [
 		"leather helmet", "leather chestplate", "leather leggings", "iron boots",
-		"beacon", "string", "wool"
+		"beacon", "string", "wool", "iron block"
 	],
 
 


### PR DESCRIPTION
There's an item frame with iron blocks on it that can be allegedly exploited.

![](https://i.gyazo.com/e13da8b6fc4f5144cc81347e9a844227.png)