### PR TITLE
Give 8 arrows per kill on Stronghold

### DIFF
--- a/DTW/Stronghold/map.json
+++ b/DTW/Stronghold/map.json
@@ -24,6 +24,11 @@
 		{ "teams": ["red"], "coords": "500.5, 18, 586.5, 180" },
 		{ "teams": ["blue"], "coords": "500.5, 18, 414.5, 0" }
 	],
+        "killstreaks": [
+                { "count": 1,
+                "repeat": true,
+                "commands": ["give %killername% arrow 8"] }
+        ],
 	"dtm": {
 		"monuments": [
 			{


### PR DESCRIPTION
[8:59 PM] Crazy: I don't suppose an arrow kill reward can be added to Stronghold?
[8:59 PM] Crazy: 16 arrows isn't a ton if you're alive for longer then 2 mins

Perhaps it will help to pick off bowspammers when you can try killing them in order to gain an advantage over them?