### PR TITLE
Changed arrows per kill from 8 to 4

### DIFF
--- a/DTW/Stronghold/map.json
+++ b/DTW/Stronghold/map.json
@@ -27,7 +27,7 @@
         "killstreaks": [
                 { "count": 1,
                 "repeat": true,
-                "commands": ["give %killername% arrow 8"] }
+                "commands": ["give %killername% arrow 4"] }
         ],
 	"dtm": {
 		"monuments": [


### PR DESCRIPTION
8 caused a little bit of bow spam when I played 4 arrows should be even :)