### PR TITLE
Clean up Cavum's JSON file

### DIFF
--- a/TDM/Cavum/map.json
+++ b/TDM/Cavum/map.json
@@ -49,7 +49,7 @@
 			"items": [
 				{"type": "item", "material": "iron sword", "slot": 0},
 				{"type": "item", "material": "bow", "slot": 1},
-				{"type": "item", "material": "golden apple", "slot": 7, "amount": 1},
+				{"type": "item", "material": "golden apple", "slot": 7},
 				{"type": "item", "material": "cooked beef", "slot": 8, "amount": 64},
 				{"type": "item", "material": "arrow", "slot": 9, "amount": 64},
 				
@@ -61,7 +61,7 @@
 		}
 	],
 	"itemremove": [
-		"leather helmet", "leather chestplate", "leather leggings", "leather boots", "iron leggings", "chainmail chestplate"
+		"leather helmet", "chainmail chestplate", "iron leggings", "leather boots"
 	],
 	"filters": [
 		{


### PR DESCRIPTION
- Removes armor not in the map in favor of armor in the spawnkit
- Removes redundant `"amount': 1`, because it's one by default