### PR TITLE
Remove Desert Country until fixed

### DIFF
--- a/rotation.txt
+++ b/rotation.txt
@@ -20,5 +20,4 @@ Cargo
 Twin Peaks
 Terrace 2
 Gardens
-Desert Country
 Kyoto


### PR DESCRIPTION
It seems like this doesn't work when we try and fix it, #113 should have extended the region @BennyDoesTheStuff had previously set up (but in the wrong direction). I propose that until the map is fixed, it's removed from the rotation.

It saves us punishing people for "glitching in the wool room" - which in retrospect is BS considering that what they "abuse" is simply a lack of a region that works properly, not so much a glitch. A glitch would be doing something like the boat trick @squid was talking about (which is another issue that needs to be corrected before the map should come back to the rotation).

On top of those two issues, you can just go high enough up to pass over the barrier wall.