### PR TITLE
Update Desert Country loadout

### DIFF
--- a/CTW/DesertCountry/map.json
+++ b/CTW/DesertCountry/map.json
@@ -76,6 +76,7 @@
 				{"material": "iron pickaxe", "slot": 2, "unbreakable": true},
 				{"material": "iron axe", "slot": 3, "unbreakable": true},
 				{"material": "wood", "slot": 4, "amount": 64},
+				{"material": "wood", "slot": 5, "amount": 64},
 				{"material": "golden apple", "slot": 7, "amount": 1},
 				{"material": "cooked beef", "slot": 8, "amount": 64},
 				{"material": "arrow", "slot": 9, "amount": 32},


### PR DESCRIPTION
Added one stack wood to the inventory because the map is big and you can easily run out of blocks if you rush or defend.