### PR TITLE
Add missing monuments to json

### DIFF
--- a/DTM/Yellowstone/map.json
+++ b/DTM/Yellowstone/map.json
@@ -24,30 +24,61 @@
 		{"teams": ["moon"], "coords": "0.5, 8, -258.5"},
 		{"teams": ["sun"], "coords": "0.5, 8, 5.4, 180"}
 	],
+	
 	"dtm": {
 		"monuments": [
 			{
-				"name": "Monument B",
+				"name": "Back Left Monument",
 				"teams": ["moon"],
 				"materials": ["obsidian"],
-				"region": { 
-					"min": "69, 22, -234",
-					"max": "69, 22, -234" 
-				},
-				"health": 1
-			},
-			{
-				"name": "Monument A",
-				"teams": ["moon"],
-				"materials": ["obsidian"],
-				"region": { 
+				"region": {
 					"min": "-69, 22, -234",
-					"max": "-69, 22, -234" 
+					"max": "-69, 22, -234"
 				},
 				"health": 1
 			},
 			{
-				"name": "Monument B&r",
+				"name": "Back Right Monument",
+				"teams": ["moon"],
+				"materials": ["obsidian"],
+				"region": {
+					"min": "69, 22, -234",
+					"max": "69, 22, -234"
+				},
+				"health": 1
+			},
+			{
+				"name": "Left Monument",
+				"teams": ["moon"],
+				"materials": ["obsidian"],
+				"region": {
+					"min": "-29, 28, -193",
+					"max": "-29, 28, -193"
+				},
+				"health": 1
+			},
+			{
+				"name": "Right Monument",
+				"teams": ["moon"],
+				"materials": ["obsidian"],
+				"region": {
+					"min": "29, 28, -193",
+					"max": "29, 28, -193"
+				},
+				"health": 1
+			},
+			{
+				"name": "Back Left Monument&r",
+				"teams": ["sun"],
+				"materials": ["obsidian"],
+				"region": {
+					"min": "69, 22, -20",
+					"max": "69, 22, -20"
+				},
+				"health": 1
+			},
+			{
+				"name": "Back Right Monument&r",
 				"teams": ["sun"],
 				"materials": ["obsidian"],
 				"region": {
@@ -57,17 +88,29 @@
 				"health": 1
 			},
 			{
-				"name": "Monument A&r",
+				"name": "Left Monument&r",
 				"teams": ["sun"],
 				"materials": ["obsidian"],
 				"region": {
-					"min": "69, 22, -20",
-					"max": "69, 22, -20"
+					"min": "29, 28, -61",
+					"max": "29, 28, -61"
+				},
+				"health": 1
+			},
+			{
+				"name": "Right Monument&r",
+				"teams": ["sun"],
+				"materials": ["obsidian"],
+				"region": {
+					"min": "-29, 28, -61",
+					"max": "-29, 28, -61"
 				},
 				"health": 1
 			}
 		]
 	},
+
+
 	"kits": [
 		{
 			"name": "Default",


### PR DESCRIPTION
Just updated the json file for Yellowstone, as the map has 4 monuments per side, while json file only had 2.