### PR TITLE
Fix Mayan Apocalypse JSON

### DIFF
--- a/DTW/Mayan_Apocalypse/map.json
+++ b/DTW/Mayan_Apocalypse/map.json
@@ -31,7 +31,7 @@
 				"teams": ["red"],
 				"materials": ["wool"],
 				"region": {
-					"min": "-127, 22, 71",
+					"min": "-127, 21, 71",
 					"max": "-124, 27, 68"
 				},
 				"health": 10


### PR DESCRIPTION
The y value was one too high, which resulted in the very lowest wool layer not counting as monument